### PR TITLE
Update peer dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>Most Basic Super-Hands Example</title>
   <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-  <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.3.0/dist/aframe-extras.min.js"></script>
+  <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.5/dist/aframe-extras.min.js"></script>
   <script src="https://unpkg.com/super-hands@1.0.0/dist/super-hands.min.js"></script>
 </head>
 
@@ -111,6 +111,11 @@ properties like `onclick`.
 
 
 ### News
+
+master branch
+
+* Updated documentation and examples with latest versions of `aframe-extras` and
+  `aframe-physics-system`. 
 
 v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -138,35 +138,8 @@ v1.0.0
   for automated testing based on motion-captured user input to improve
   regression detection
 
-v0.3.1
-
-* New: integration with GlobalEventHandlers for easy reactivity via element
-  properties such as `onclick`
-* New: `clickable` reaction component for interacting with an entity
-  without moving it
-
-
-v0.3.0
-
-* Confirmed compatibility with A-Frame v0.5.0 (no changes)
-
-v0.2.4
-
-* Fix error with systm registration that broke most everything
-
-v0.2.3
-
-* Fix `usePhysics: only` not being honored by `grabbable`
-* Fix handling of edge cases in `stretchable`
-* `super-hands` now respects with custom button mappings applied after initalization
-* Added `super-hands` system to better manage links between two controllers
-* Adding unit testing to prepare for updates
-
 #### Known Issues
 
-* Collision zones for stretched entities don't update to new scale (`sphere-collider` does not take entity scale into account)
-  * This makes it difficult to shrink back down if you've enlarged yourself via
-    `a-locomotor` & `stretchable`
 * When both hands are hovering an entity and one leaves, the entity will lose
   the hover state for one tick
   * Related to messaging from `sphere-collider`; unable to distinguish which
@@ -177,11 +150,10 @@ v0.2.3
 
 #### Compatibility
 
-| A-Frame Version | super-hands Version |
-| --- | --- |
-| v0.6.x | ^v1.0.0 |
-| v0.5.x | v1.0.0 |
-| v0.4.x | v0.2.4 |
+| A-Frame Version | super-hands Version | aframe-extras Version | aframe-physics-system Version |
+| --- | --- | --- | --- |
+| v0.5.x | ^v1.0.0 |^v3.8.5 | ^v1.4.1 |
+| v0.4.x | v0.2.4 | v3.7.0 | v1.3.0 |
 
 ### API
 

--- a/examples/events/index.html
+++ b/examples/events/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>A-Frame Super Hands Component - GlobalEventHandler Integration</title>
     <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.3.0/dist/aframe-extras.min.js"></script>
+    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.5/dist/aframe-extras.min.js"></script>
     <!-- Replace "../build.js" with the super-hands distribution to run locally:
         "https://unpkg.com/super-hands@1.0.0/dist/super-hands.min.js" -->
     <script src="../build.js"></script>

--- a/examples/hands/index.html
+++ b/examples/hands/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>A-Frame Super Hands Component - Hand Controls</title>
     <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.3.0/dist/aframe-extras.min.js"></script>
+    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.5/dist/aframe-extras.min.js"></script>
     <script src="https://rawgit.com/ngokevin/aframe-event-set-component/master/dist/aframe-event-set-component.min.js"></script>
     <!-- Replace "../build.js" with the super-hands distribution to run locally:
         "https://unpkg.com/super-hands@1.0.0/dist/super-hands.min.js" -->

--- a/examples/locomotion/index.html
+++ b/examples/locomotion/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>A-Frame Super Hands Component - Hand Controls</title>
     <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.3.0/dist/aframe-extras.min.js"></script>
+    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.5/dist/aframe-extras.min.js"></script>
     <script src="https://rawgit.com/ngokevin/aframe-event-set-component/master/dist/aframe-event-set-component.min.js"></script>
     <script src="a-painter-loader-component.min.js"></script>
     <!-- Replace "../build.js" with the super-hands distribution to run locally:

--- a/examples/physics/index.html
+++ b/examples/physics/index.html
@@ -2,8 +2,8 @@
   <head>
     <title>A-Frame Super Hands Component - Vive With Physics</title>
     <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.3.0/dist/aframe-extras.min.js"></script>
-    <script src="//cdn.rawgit.com/donmccurdy/aframe-physics-system/v1.3.0/dist/aframe-physics-system.min.js"></script>
+    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.5/dist/aframe-extras.min.js"></script>
+    <script src="//cdn.rawgit.com/donmccurdy/aframe-physics-system/v1.4.1/dist/aframe-physics-system.min.js"></script>
     <script src="https://rawgit.com/ngokevin/aframe-event-set-component/master/dist/aframe-event-set-component.min.js"></script>
     <!-- Replace "../build.js" with the super-hands distribution to run locally:
         "https://unpkg.com/super-hands@1.0.0/dist/super-hands.min.js" -->
@@ -19,14 +19,6 @@
           });
         }
       });
-      //delayed addition of physics body component to controllers due to AFRAME 0.4.0 changes
-      AFRAME.registerComponent('controller-loaded', {
-        init: function() {
-          this.el.addEventListener('model-loaded', function() {
-            this.addState('loaded');
-          });
-        }
-      });
     </script>
   </head>
   <body>
@@ -34,9 +26,8 @@
       <a-assets>
         <img id="colortransform" src="./colortransform.png" />
         <a-mixin id="controller" super-hands
-                 controller-loaded
-                 sphere-collider="objects: .cube, .transformer"></a-mixin>
-        <a-mixin id="controller-loaded" static-body="shape: sphere; sphereRadius: 0.02;"></a-mixin>
+                 sphere-collider="objects: .cube, .transformer"
+                 static-body="shape: sphere; sphereRadius: 0.02;"></a-mixin>
         <a-mixin id="cube" geometry="primitive: box; width: 0.33; height: 0.33; depth: 0.33"
                  hoverable grabbable stretchable drag-droppable
                  dynamic-body></a-mixin>

--- a/examples/sticky/index.html
+++ b/examples/sticky/index.html
@@ -2,22 +2,12 @@
   <head>
     <title>A-Frame Super Hands Component - Sticky Grab</title>
     <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.3.0/dist/aframe-extras.min.js"></script>
-    <script src="//cdn.rawgit.com/donmccurdy/aframe-physics-system/v1.3.0/dist/aframe-physics-system.min.js"></script>
+    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.5/dist/aframe-extras.min.js"></script>
+    <script src="//cdn.rawgit.com/donmccurdy/aframe-physics-system/v1.4.1/dist/aframe-physics-system.min.js"></script>
     <script src="https://rawgit.com/ngokevin/aframe-event-set-component/master/dist/aframe-event-set-component.min.js"></script>
     <!-- Replace "../build.js" with the super-hands distribution to run locally:
         "https://unpkg.com/super-hands@1.0.0/dist/super-hands.min.js" -->
     <script src="../build.js"></script>
-    <script>
-      //delayed addition of physics body component to controllers due to AFRAME 0.4.0 changes
-      AFRAME.registerComponent('controller-loaded', {
-        init: function() {
-          this.el.addEventListener('model-loaded', function() {
-            this.addState('loaded');
-          });
-        }
-      });
-    </script>
   </head>
   <body>
     <a-scene physics>
@@ -25,9 +15,8 @@
         <img id="grid" src="grid.png"/>
         <a-mixin id="controller"
                  super-hands="grabStartButtons: triggerdown; grabEndButtons: gripdown; stretchStartButtons: trackpaddown; stretchEndButtons: trackpadup"
-                 controller-loaded
+                 static-body="shape: sphere; sphereRadius: 0.02;"
                  sphere-collider="objects: a-cone#stick"></a-mixin>
-        <a-mixin id="controller-loaded" static-body="shape: sphere; sphereRadius: 0.02;"></a-mixin>
         <a-mixin id="ball" geometry="primitive: sphere; radius: 0.33"
                  dynamic-body></a-mixin>
         <a-mixin id="floor" material="src: #grid; repeat: 50 50" static-body

--- a/examples/super-basic/index.html
+++ b/examples/super-basic/index.html
@@ -1,7 +1,7 @@
 <head>
   <title>Most Basic Super-Hands Example</title>
   <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-  <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.3.0/dist/aframe-extras.min.js"></script>
+  <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.5/dist/aframe-extras.min.js"></script>
   <script src="https://unpkg.com/super-hands@1.0.0/dist/super-hands.min.js"></script>
 </head>
 

--- a/examples/touch/index.html
+++ b/examples/touch/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>A-Frame Super Hands Component - Oculus Touch Controls</title>
     <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.3.0/dist/aframe-extras.min.js"></script>
+    <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.5/dist/aframe-extras.min.js"></script>
     <script src="https://rawgit.com/ngokevin/aframe-event-set-component/master/dist/aframe-event-set-component.min.js"></script>
     <!-- Replace "../build.js" with the super-hands distribution to run locally:
         "https://unpkg.com/super-hands@1.0.0/dist/super-hands.min.js" -->

--- a/machinima_tests/main.js
+++ b/machinima_tests/main.js
@@ -5,11 +5,3 @@ AFRAME.registerComponent('sphere-collider', require('aframe-extras').misc['spher
 require('aframe-event-set-component');
 require('aframe-motion-capture-components');
 require('../index.js');
-// delayed addition of physics body component to controllers due to AFRAME 0.4.0 changes
-AFRAME.registerComponent('controller-loaded', {
-  init: function () {
-    this.el.addEventListener('model-loaded', function () {
-      this.addState('loaded');
-    });
-  }
-});

--- a/machinima_tests/scenes/physics.html
+++ b/machinima_tests/scenes/physics.html
@@ -6,17 +6,17 @@
     <a-scene avatar-recorder="spectatorPlay: true; spectatorPosition: 0 1.6 2" physics>
       <a-assets>
         <!-- <img id="grid" src="grid.png"/> -->
-  
+
         <a-mixin id="controller" super-hands controller-loaded
-                 sphere-collider="objects: .dynamic"></a-mixin>
-        <a-mixin id="controller-loaded" static-body="shape: sphere; sphereRadius: 0.02;"></a-mixin>
+                 sphere-collider="objects: .dynamic"
+                 static-body="shape: sphere; sphereRadius: 0.02;"></a-mixin>
         <a-mixin id="sp-hovered" material="wireframe: false;"></a-mixin>
       </a-assets>
       <a-entity id="lhand" hand-controls="left" mixin="controller"></a-entity>
       <a-entity id="rhand" hand-controls="right" mixin="controller"></a-entity>
-      <a-entity id="target" class="dynamic" position="0 0.051 -0.25" 
-                geometry="primitive:box; width: 1.25; height: 0.1; depth: 0.1;" 
-                material="color: red" 
+      <a-entity id="target" class="dynamic" position="0 0.051 -0.25"
+                geometry="primitive:box; width: 1.25; height: 0.1; depth: 0.1;"
+                material="color: red"
                 dynamic-body grabbable></a-entity>
 
       <a-plane rotation="-90 0 0" color="#888" static-body

--- a/machinima_tests/super_hands/super-hands-machinima.test.js
+++ b/machinima_tests/super_hands/super-hands-machinima.test.js
@@ -164,8 +164,7 @@ suite('Nested object targeting', function () {
     }, { once: true });
   });
 });
-// can't get a stable physiccs test working
-suite.skip('Physics grab', function () {
+suite('Physics grab', function () {
   this.timeout(0); // disable Mocha timeout within tests
   setup(function (done) {
     /* inject the scene html into the testing docoument */

--- a/machinima_tests/super_hands/super-hands-machinima.test.js
+++ b/machinima_tests/super_hands/super-hands-machinima.test.js
@@ -164,7 +164,7 @@ suite('Nested object targeting', function () {
     }, { once: true });
   });
 });
-suite('Physics grab', function () {
+suite.only('Physics grab', function () {
   this.timeout(0); // disable Mocha timeout within tests
   setup(function (done) {
     /* inject the scene html into the testing docoument */

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   "devDependencies": {
     "aframe": "^0.5.0",
     "aframe-event-set-component": "^3.0.2",
-    "aframe-extras": "^3.7.0",
+    "aframe-extras": "^3.8.5",
     "aframe-motion-capture-components": "^0.1.4",
-    "aframe-physics-system": "^1.3.0",
+    "aframe-physics-system": "^1.4.1",
     "babel-loader": "^6.2.10",
     "babel-preset-es2015": "^6.22.0",
     "babelify": "^7.3.0",


### PR DESCRIPTION
Update references to `aframe-extras` and `aframe-physics-system` to latest version. 

* This resolves a previous known issue with collision zones not syncing with stretched entity size changes. 
* Removed a deprecated hack in physics examples (`contoller-loaded` component) as underlying issue has been resoled in `aframe-physics-system`

Fix #42 