### PR TITLE
Feature/set grab target

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ AFRAME.registerComponent('super-hands', {
     this.dispatchMouseEventAll('mousedown', this.el)
     this.gehClicking = new Set(this.hoverEls)
     if (!carried) {
-      carried = this.findTarget(this.GRAB_EVENT, {
+      carried = evt.detail.targetEntity || this.findTarget(this.GRAB_EVENT, {
         hand: this.el,
         buttonEvent: evt
       })

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ AFRAME.registerComponent('super-hands', {
     this.dispatchMouseEventAll('mousedown', this.el)
     this.gehClicking = new Set(this.hoverEls)
     if (!carried) {
-      carried = evt.detail.targetEntity || this.findTarget(this.GRAB_EVENT, {
+      carried = (evt.detail ? evt.detail.targetEntity : false) || this.findTarget(this.GRAB_EVENT, {
         hand: this.el,
         buttonEvent: evt
       })


### PR DESCRIPTION
I have run `npm run test:machinima`, and this patch passes all machinima tests: yes

Optionally explicitly specify which entity to grab when `grab-start` is fired. This is useful for things like "spawners" (imagine a box spawner that when you grab, spawns a new box in your hand, leaving the original spawner in place).
