### PR TITLE
refactor distance sorting

### DIFF
--- a/tests/super-hands-component/super-hands-core.test.js
+++ b/tests/super-hands-component/super-hands-core.test.js
@@ -503,7 +503,10 @@ suite('state tracking', function () {
     this.sh1.onHit({
       detail: {
         els: [this.target1, this.target2],
-        intersections: [{distance: 1}, {distance: 2}]
+        intersections: [
+          { distance: 1, object: { el: this.target1 } },
+          { distance: 2, object: { el: this.target2 } }
+        ]
       }
     })
     assert.strictEqual(this.sh1.state.get(this.sh1.HOVER_EVENT).id, 'target1')
@@ -514,34 +517,29 @@ suite('state tracking', function () {
     assert.strictEqual(this.sh1.state.get(this.sh1.HOVER_EVENT).id, 'target2')
   })
   test('hover targeting updates as distances change', function () {
+    let time = 10000
     this.hand1.setAttribute('super-hands', { colliderEventProperty: 'els' })
     this.target1.addEventListener('hover-start', e => e.preventDefault())
     this.target2.addEventListener('hover-start', e => e.preventDefault())
     this.target3.addEventListener('hover-start', e => e.preventDefault())
+    const target1Sect = { distance: 1, object: { el: this.target1 } }
+    const target2Sect = { distance: 2, object: { el: this.target2 } }
     this.sh1.onHit({
       detail: {
         els: [this.target1, this.target2],
-        intersections: [{ distance: 1 }, { distance: 2 }]
+        intersections: [target1Sect, target2Sect]
       }
     })
     assert.strictEqual(this.sh1.state.get(this.sh1.HOVER_EVENT).id, 'target1')
-    this.sh1.onHit({
-      detail: {
-        els: [this.target1, this.target2],
-        intersections: [{ distance: 1 }, { distance: 0.5 }]
-      }
-    })
+    target2Sect.distance = 0.5
+    this.sh1.tick(time)
     assert.strictEqual(this.sh1.state.get(this.sh1.HOVER_EVENT).id, 'target2', 'closer')
-    assert.sameOrderedMembers(this.sh1.hoverElsDist, [1, 0.5], 'closer')
     assert.sameOrderedMembers(this.sh1.hoverEls, [this.target1, this.target2], 'closer')
-    this.sh1.onHit({
-      detail: {
-        els: [this.target1, this.target2],
-        intersections: [{ distance: 2 }, { distance: 3 }]
-      }
-    })
+    target2Sect.distance = 3
+    target1Sect.distance = 2
+    time += 10000
+    this.sh1.tick(time)
     assert.strictEqual(this.sh1.state.get(this.sh1.HOVER_EVENT).id, 'target1', 'further')
-    assert.sameOrderedMembers(this.sh1.hoverElsDist, [3, 2], 'further')
     assert.sameOrderedMembers(this.sh1.hoverEls, [this.target2, this.target1], 'further')
   })
   test('released el placed back at top of stack', function () {


### PR DESCRIPTION
Keep a handle on the intersections object, and periodically check if the distances have changed and reorder the stack.The order will remain inaccurate with the A-Frame core raycaster, which doesn't update intersection objects, but this creates an API for live updated distances without having to do array searches. 
