### PR TITLE
max grab behavior attribute

### DIFF
--- a/reaction_components/grabbable.js
+++ b/reaction_components/grabbable.js
@@ -7,6 +7,7 @@ const base = inherit({}, physicsCore, buttonsCore)
 AFRAME.registerComponent('grabbable', inherit(base, {
   schema: {
     maxGrabbers: {type: 'int', default: NaN},
+    maxGrabBehavior: {default: 'nothing', oneOf: ['nothing', 'drop']},
     invert: {default: false},
     suppressY: {default: false}
   },
@@ -74,9 +75,13 @@ AFRAME.registerComponent('grabbable', inherit(base, {
       return
     }
     // room for more grabbers?
-    const grabAvailable = !Number.isFinite(this.data.maxGrabbers) ||
+    let grabAvailable = !Number.isFinite(this.data.maxGrabbers) ||
         this.grabbers.length < this.data.maxGrabbers
-
+    if (Number.isFinite(this.data.maxGrabbers) && !grabAvailable && 
+        this.grabbed && this.data.maxGrabBehavior == 'drop') {
+      this.grabbers[0].components['super-hands'].onGrabEndButton()
+      grabAvailable = true
+    }
     if (this.grabbers.indexOf(evt.detail.hand) === -1 && grabAvailable) {
       if (!evt.detail.hand.object3D) {
         console.warn('grabbable entities must have an object3D')

--- a/reaction_components/grabbable.js
+++ b/reaction_components/grabbable.js
@@ -77,8 +77,8 @@ AFRAME.registerComponent('grabbable', inherit(base, {
     // room for more grabbers?
     let grabAvailable = !Number.isFinite(this.data.maxGrabbers) ||
         this.grabbers.length < this.data.maxGrabbers
-    if (Number.isFinite(this.data.maxGrabbers) && !grabAvailable && 
-        this.grabbed && this.data.maxGrabBehavior == 'drop') {
+    if (Number.isFinite(this.data.maxGrabbers) && !grabAvailable &&
+        this.grabbed && this.data.maxGrabBehavior === 'drop') {
       this.grabbers[0].components['super-hands'].onGrabEndButton()
       grabAvailable = true
     }


### PR DESCRIPTION
I have run `npm run test:machinima`, and this patch passes all machinima tests: no

 add property maxGrabBehavior to specify the behavior to follow when maxGrabbers is reached.

Default is what it does now, which is nothing. Also added 'drop' which ends the grab with the the first hand currently grabbing so that the new hand can grab.