### PR TITLE
Fix link in examples (laser pointer setup for 3DOF controllers)

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -99,7 +99,7 @@
       <img class="preview" src="./assets/hand-controls.jpg"/>
       <div class="bonus"></div>
     </a>
-    <p><a href="mouse/index-laser.html">Laser pointer setup for 3DOF controllers</a></p>
+    <p><a href="mouse/index.html">Laser pointer setup for 3DOF controllers</a></p>
     <p><a href="mouse/index-mouse.html">Mouse cursor based version for desktop</a></p>
     <p><ul>
       <li>Grabbed entities move by controller position and rotation</li>


### PR DESCRIPTION
Currently, the link points to a non-existent page, I guess the correct one is this one.

I have run `npm run test:machinima`, and this patch passes all machinima tests: no
(but I guess that shouldn't be a problem, since this is only a change to an HTML page)
